### PR TITLE
change platform to platforms in cdflow.yaml nad release_metadata.json

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -26,7 +26,7 @@ type config struct {
 	dockerfile string
 	context    string
 	buildx     bool
-	platform   string
+	platforms  string
 	cacheFrom  string
 	cacheTo    string
 }
@@ -60,9 +60,9 @@ func Run(ecrClient ecriface.ECRAPI, runner CommandRunner, params map[string]inte
 	}
 
 	data, err := json.Marshal(map[string]string{
-		"image":    image,
-		"buildx":   strconv.FormatBool(config.buildx),
-		"platform": config.platform})
+		"image":     image,
+		"buildx":    strconv.FormatBool(config.buildx),
+		"platforms": config.platforms})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -96,8 +96,8 @@ func buildWithBuildx(config *config, image string, runner CommandRunner) error {
 	runner.Run("docker", builderCreateArgs...)
 
 	buildArgs := []string{"buildx", "build", "--push"}
-	if config.platform != "" {
-		buildArgs = append(buildArgs, "--platform", config.platform)
+	if config.platforms != "" {
+		buildArgs = append(buildArgs, "--platform", config.platforms)
 	}
 
 	if config.cacheFrom != "" {
@@ -171,11 +171,11 @@ func getConfig(buildID string, params map[string]interface{}) (*config, error) {
 		}
 	}
 
-	platformI, ok := params["platform"]
+	platformsI, ok := params["platforms"]
 	if ok {
-		result.platform, ok = platformI.(string)
+		result.platforms, ok = platformsI.(string)
 		if !ok {
-			return nil, fmt.Errorf("unexpected type for build.%v.params.platform: %T (should be string)", buildID, platformI)
+			return nil, fmt.Errorf("unexpected type for build.%v.params.platforms: %T (should be string)", buildID, platformsI)
 		}
 	}
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -94,8 +94,8 @@ func TestBuildxRun(t *testing.T) {
 	commandRunner := &mockCommandRunner{}
 
 	params := map[string]interface{}{
-		"buildx":   true,
-		"platform": "linux/arm64,linux/386,linux/s390x",
+		"buildx":    true,
+		"platforms": "linux/arm64,linux/386,linux/s390x",
 	}
 
 	// When


### PR DESCRIPTION
This PR changes the cdflow.yaml and release_metadata.json platform parameter to platforms. But docker buildx uses the option --platform 